### PR TITLE
Reapply signature filter changes on top of 6.1.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -151,6 +151,7 @@ libavutil/ffversion.h .version:
 -include .version
 
 install: install-libs install-headers
+	$(INSTALL) -m 644 config.h "$(INCDIR)"
 
 install-libs: install-libs-yes
 

--- a/configure
+++ b/configure
@@ -3830,6 +3830,8 @@ sharpness_vaapi_filter_deps="vaapi"
 showcqt_filter_deps="avformat swscale"
 showcqt_filter_suggest="libfontconfig libfreetype"
 signature_filter_deps="gpl avcodec avformat"
+signature_cuda_filter_deps="ffnvcodec gpl avcodec avformat"
+signature_cuda_filter_deps_any="cuda_nvcc cuda_llvm gpl avcodec avformat"
 smartblur_filter_deps="gpl swscale"
 sobel_opencl_filter_deps="opencl"
 sofalizer_filter_deps="libmysofa"
@@ -4560,10 +4562,10 @@ fi
 
 if enabled cuda_nvcc; then
     nvcc_default="nvcc"
-    nvccflags_default="-gencode arch=compute_30,code=sm_30 -O2"
+    nvccflags_default="-gencode arch=compute_52,code=sm_52 -O2"
 else
     nvcc_default="clang"
-    nvccflags_default="--cuda-gpu-arch=sm_30 -O2"
+    nvccflags_default="--cuda-gpu-arch=sm_52 -O2"
     NVCC_C=""
 fi
 

--- a/libavfilter/Makefile
+++ b/libavfilter/Makefile
@@ -492,6 +492,8 @@ OBJS-$(CONFIG_SHUFFLEPLANES_FILTER)          += vf_shuffleplanes.o
 OBJS-$(CONFIG_SIDEDATA_FILTER)               += f_sidedata.o
 OBJS-$(CONFIG_SIGNALSTATS_FILTER)            += vf_signalstats.o
 OBJS-$(CONFIG_SIGNATURE_FILTER)              += vf_signature.o
+OBJS-$(CONFIG_SIGNATURE_CUDA_FILTER)         += vf_signature_cuda.o \
+                                                vf_signature_cuda.ptx.o
 OBJS-$(CONFIG_SMARTBLUR_FILTER)              += vf_smartblur.o
 OBJS-$(CONFIG_SOBEL_FILTER)                  += vf_convolution.o
 OBJS-$(CONFIG_SOBEL_OPENCL_FILTER)           += vf_convolution_opencl.o opencl.o \

--- a/libavfilter/allfilters.c
+++ b/libavfilter/allfilters.c
@@ -464,6 +464,7 @@ extern const AVFilter ff_vf_shuffleplanes;
 extern const AVFilter ff_vf_sidedata;
 extern const AVFilter ff_vf_signalstats;
 extern const AVFilter ff_vf_signature;
+extern const AVFilter ff_vf_signature_cuda;
 extern const AVFilter ff_vf_siti;
 extern const AVFilter ff_vf_smartblur;
 extern const AVFilter ff_vf_sobel;

--- a/libavfilter/avfilter.h
+++ b/libavfilter/avfilter.h
@@ -1522,6 +1522,24 @@ char *avfilter_graph_dump(AVFilterGraph *graph, const char *options);
 int avfilter_graph_request_oldest(AVFilterGraph *graph);
 
 /**
+ * compare two signature files whether those matches or not.
+ * @param signpath1        full path of the first signature file.
+ * @param signpath2        full path of the second signature file.
+ * @return  <0: error, 0: no matchiing 1: partial matching 2: whole matching.
+ */
+int avfilter_compare_sign_bypath(char *signpath1, char *signpath2);
+
+/**
+ * compare two signature buffers whether those matches or not.
+ * @param signbuf1        the pointer of the first signature buffer.
+ * @param signbuf2        the pointer of the second signature buffer.
+ * @param len1            the length of the first signature buffer.
+ * @param len2            the length of the second signature buffer.
+ * @return  <0: error, 0: no matchiing 1: partial matching 2: whole matching.
+ */
+int avfilter_compare_sign_bybuff(uint8_t *signbuf1, int len1, uint8_t *signbuf2, int len2);
+
+/**
  * @}
  */
 

--- a/libavfilter/signature_lookup.c
+++ b/libavfilter/signature_lookup.c
@@ -244,9 +244,9 @@ static MatchingInfo* get_matching_parameters(AVFilterContext *ctx, SignatureCont
                     if (pairs[i].b[j] != pairs[k].b[l]) {
                         /* linear regression */
                         m = (pairs[k].b_pos[l]-pairs[i].b_pos[j]) / (k-i); /* good value between 0.0 - 2.0 */
-                        framerate = (int) (m*30 + 0.5); /* round up to 0 - 60 */
+                        framerate = nearbyint(m*30 + 0.5); /* round up to 0 - 60 */
                         if (framerate>0 && framerate <= MAX_FRAMERATE) {
-                            offset = pairs[i].b_pos[j] - ((int) (m*i + 0.5)); /* only second part has to be rounded up */
+                            offset = pairs[i].b_pos[j] - nearbyint(m*i + 0.5); /* only second part has to be rounded up */
                             if (offset > -HOUGH_MAX_OFFSET && offset < HOUGH_MAX_OFFSET) {
                                 if (pairs[i].dist < pairs[k].dist) {
                                     if (pairs[i].dist < hspace[framerate-1][offset+HOUGH_MAX_OFFSET].dist) {
@@ -427,6 +427,7 @@ static MatchingInfo evaluate_parameters(AVFilterContext *ctx, SignatureContext *
     for (; infos != NULL; infos = infos->next) {
         a = infos->first;
         b = infos->second;
+	if (a == NULL || b == NULL) continue;
         while (1) {
             dist = get_l1dist(ctx, sc, a->framesig, b->framesig);
 
@@ -541,6 +542,7 @@ static MatchingInfo lookup_signatures(AVFilterContext *ctx, SignatureContext *sc
     cs2 = second->coarsesiglist;
 
     /* score of bestmatch is 0, if no match is found */
+    memset(&bestmatch, 0x00, sizeof(MatchingInfo));
     bestmatch.score = 0;
     bestmatch.meandist = 99999;
     bestmatch.whole = 0;
@@ -577,4 +579,377 @@ static MatchingInfo lookup_signatures(AVFilterContext *ctx, SignatureContext *sc
     } while (find_next_coarsecandidate(sc, second->coarsesiglist, &cs, &cs2, 0) && !bestmatch.whole);
     return bestmatch;
 
+}
+
+static int get_block_size(const Block *b)
+{
+    return (b->to.y - b->up.y + 1) * (b->to.x - b->up.x + 1);
+}
+
+static uint64_t get_block_sum(StreamContext *sc, uint64_t intpic[32][32], const Block *b)
+{
+    uint64_t sum = 0;
+
+    int x0, y0, x1, y1;
+
+    x0 = b->up.x;
+    y0 = b->up.y;
+    x1 = b->to.x;
+    y1 = b->to.y;
+
+    if (x0-1 >= 0 && y0-1 >= 0) {
+        sum = intpic[y1][x1] + intpic[y0-1][x0-1] - intpic[y1][x0-1] - intpic[y0-1][x1];
+    } else if (x0-1 >= 0) {
+        sum = intpic[y1][x1] - intpic[y1][x0-1];
+    } else if (y0-1 >= 0) {
+        sum = intpic[y1][x1] - intpic[y0-1][x1];
+    } else {
+        sum = intpic[y1][x1];
+    }
+    return sum;
+}
+
+static int cmp(const void *x, const void *y)
+{
+    const uint64_t *a = x, *b = y;
+    return *a < *b ? -1 : ( *a > *b ? 1 : 0 );
+}
+
+/**
+ * sets the bit at position pos to 1 in data
+ */
+static void set_bit(uint8_t* data, size_t pos)
+{
+    uint8_t mask = 1 << 7-(pos%8);
+    data[pos/8] |= mask;
+}
+
+static int xml_export(AVFilterContext *ctx, StreamContext *sc, const char* filename)
+{
+    FineSignature* fs;
+    CoarseSignature* cs;
+    int i, j;
+    FILE* f;
+    unsigned int pot3[5] = { 3*3*3*3, 3*3*3, 3*3, 3, 1 };
+
+    f = fopen(filename, "w");
+    if (!f) {
+        int err = AVERROR(EINVAL);
+        char buf[128];
+        av_strerror(err, buf, sizeof(buf));
+        av_log(ctx, AV_LOG_ERROR, "cannot open xml file %s: %s\n", filename, buf);
+        return err;
+    }
+
+    /* header */
+    fprintf(f, "<?xml version='1.0' encoding='ASCII' ?>\n");
+    fprintf(f, "<Mpeg7 xmlns=\"urn:mpeg:mpeg7:schema:2001\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:schemaLocation=\"urn:mpeg:mpeg7:schema:2001 schema/Mpeg7-2001.xsd\">\n");
+    fprintf(f, "  <DescriptionUnit xsi:type=\"DescriptorCollectionType\">\n");
+    fprintf(f, "    <Descriptor xsi:type=\"VideoSignatureType\">\n");
+    fprintf(f, "      <VideoSignatureRegion>\n");
+    fprintf(f, "        <VideoSignatureSpatialRegion>\n");
+    fprintf(f, "          <Pixel>0 0 </Pixel>\n");
+    fprintf(f, "          <Pixel>%d %d </Pixel>\n", sc->w - 1, sc->h - 1);
+    fprintf(f, "        </VideoSignatureSpatialRegion>\n");
+    fprintf(f, "        <StartFrameOfSpatialRegion>0</StartFrameOfSpatialRegion>\n");
+    /* hoping num is 1, other values are vague */
+    fprintf(f, "        <MediaTimeUnit>%d</MediaTimeUnit>\n", sc->time_base.den / sc->time_base.num);
+    fprintf(f, "        <MediaTimeOfSpatialRegion>\n");
+    fprintf(f, "          <StartMediaTimeOfSpatialRegion>0</StartMediaTimeOfSpatialRegion>\n");
+    fprintf(f, "          <EndMediaTimeOfSpatialRegion>%" PRIu64 "</EndMediaTimeOfSpatialRegion>\n", sc->coarseend->last->pts);
+    fprintf(f, "        </MediaTimeOfSpatialRegion>\n");
+
+    /* coarsesignatures */
+    for (cs = sc->coarsesiglist; cs; cs = cs->next) {
+        fprintf(f, "        <VSVideoSegment>\n");
+        fprintf(f, "          <StartFrameOfSegment>%" PRIu32 "</StartFrameOfSegment>\n", cs->first->index);
+        fprintf(f, "          <EndFrameOfSegment>%" PRIu32 "</EndFrameOfSegment>\n", cs->last->index);
+        fprintf(f, "          <MediaTimeOfSegment>\n");
+        fprintf(f, "            <StartMediaTimeOfSegment>%" PRIu64 "</StartMediaTimeOfSegment>\n", cs->first->pts);
+        fprintf(f, "            <EndMediaTimeOfSegment>%" PRIu64 "</EndMediaTimeOfSegment>\n", cs->last->pts);
+        fprintf(f, "          </MediaTimeOfSegment>\n");
+        for (i = 0; i < 5; i++) {
+            fprintf(f, "          <BagOfWords>");
+            for (j = 0; j < 31; j++) {
+                uint8_t n = cs->data[i][j];
+                if (j < 30) {
+                    fprintf(f, "%d  %d  %d  %d  %d  %d  %d  %d  ", (n & 0x80) >> 7,
+                                                                   (n & 0x40) >> 6,
+                                                                   (n & 0x20) >> 5,
+                                                                   (n & 0x10) >> 4,
+                                                                   (n & 0x08) >> 3,
+                                                                   (n & 0x04) >> 2,
+                                                                   (n & 0x02) >> 1,
+                                                                   (n & 0x01));
+                } else {
+                    /* print only 3 bit in last byte */
+                    fprintf(f, "%d  %d  %d ", (n & 0x80) >> 7,
+                                              (n & 0x40) >> 6,
+                                              (n & 0x20) >> 5);
+                }
+            }
+            fprintf(f, "</BagOfWords>\n");
+        }
+        fprintf(f, "        </VSVideoSegment>\n");
+    }
+
+    /* finesignatures */
+    for (fs = sc->finesiglist; fs; fs = fs->next) {
+        fprintf(f, "        <VideoFrame>\n");
+        fprintf(f, "          <MediaTimeOfFrame>%" PRIu64 "</MediaTimeOfFrame>\n", fs->pts);
+        /* confidence */
+        fprintf(f, "          <FrameConfidence>%d</FrameConfidence>\n", fs->confidence);
+        /* words */
+        fprintf(f, "          <Word>");
+        for (i = 0; i < 5; i++) {
+            fprintf(f, "%d ", fs->words[i]);
+            if (i < 4) {
+                fprintf(f, " ");
+            }
+        }
+        fprintf(f, "</Word>\n");
+        /* framesignature */
+        fprintf(f, "          <FrameSignature>");
+        for (i = 0; i< SIGELEM_SIZE/5; i++) {
+            if (i > 0) {
+                fprintf(f, " ");
+            }
+            fprintf(f, "%d ", fs->framesig[i] / pot3[0]);
+            for (j = 1; j < 5; j++)
+                fprintf(f, " %d ", fs->framesig[i] % pot3[j-1] / pot3[j] );
+        }
+        fprintf(f, "</FrameSignature>\n");
+        fprintf(f, "        </VideoFrame>\n");
+    }
+    fprintf(f, "      </VideoSignatureRegion>\n");
+    fprintf(f, "    </Descriptor>\n");
+    fprintf(f, "  </DescriptionUnit>\n");
+    fprintf(f, "</Mpeg7>\n");
+
+    fclose(f);
+    return 0;
+}
+
+static int binary_export(AVFilterContext *ctx, StreamContext *sc, const char* filename)
+{
+    FILE* f;
+    FineSignature* fs;
+    CoarseSignature* cs;
+    uint32_t numofsegments = (sc->lastindex + 44)/45;
+    int i, j;
+    PutBitContext buf;
+    /* buffer + header + coarsesignatures + finesignature */
+    int len = (512 + 6 * 32 + 3*16 + 2 +
+        numofsegments * (4*32 + 1 + 5*243) +
+        sc->lastindex * (2 + 32 + 6*8 + 608)) / 8;
+    uint8_t* buffer = av_malloc_array(len, sizeof(uint8_t));
+    if (!buffer)
+        return AVERROR(ENOMEM);
+
+    f = fopen(filename, "wb");
+    if (!f) {
+        int err = AVERROR(EINVAL);
+        char buf[128];
+        av_strerror(err, buf, sizeof(buf));
+        av_log(ctx, AV_LOG_ERROR, "cannot open file %s: %s\n", filename, buf);
+        av_freep(&buffer);
+        return err;
+    }
+    init_put_bits(&buf, buffer, len);
+
+    put_bits32(&buf, 1); /* NumOfSpatial Regions, only 1 supported */
+    put_bits(&buf, 1, 1); /* SpatialLocationFlag, always the whole image */
+    put_bits32(&buf, 0); /* PixelX,1 PixelY,1, 0,0 */
+    put_bits(&buf, 16, sc->w-1 & 0xFFFF); /* PixelX,2 */
+    put_bits(&buf, 16, sc->h-1 & 0xFFFF); /* PixelY,2 */
+    put_bits32(&buf, 0); /* StartFrameOfSpatialRegion */
+    put_bits32(&buf, sc->lastindex); /* NumOfFrames */
+    /* hoping num is 1, other values are vague */
+    /* den/num might be greater than 16 bit, so cutting it */
+    put_bits(&buf, 16, 0xFFFF & (sc->time_base.den / sc->time_base.num)); /* MediaTimeUnit */
+    put_bits(&buf, 1, 1); /* MediaTimeFlagOfSpatialRegion */
+    put_bits32(&buf, 0); /* StartMediaTimeOfSpatialRegion */
+    put_bits32(&buf, 0xFFFFFFFF & sc->coarseend->last->pts); /* EndMediaTimeOfSpatialRegion */
+    put_bits32(&buf, numofsegments); /* NumOfSegments */
+    /* coarsesignatures */
+    for (cs = sc->coarsesiglist; cs; cs = cs->next) {
+        put_bits32(&buf, cs->first->index); /* StartFrameOfSegment */
+        put_bits32(&buf, cs->last->index); /* EndFrameOfSegment */
+        put_bits(&buf, 1, 1); /* MediaTimeFlagOfSegment */
+        put_bits32(&buf, 0xFFFFFFFF & cs->first->pts); /* StartMediaTimeOfSegment */
+        put_bits32(&buf, 0xFFFFFFFF & cs->last->pts); /* EndMediaTimeOfSegment */
+        for (i = 0; i < 5; i++) {
+            /* put 243 bits ( = 7 * 32 + 19 = 8 * 28 + 19) into buffer */
+            for (j = 0; j < 30; j++) {
+                put_bits(&buf, 8, cs->data[i][j]);
+            }
+            put_bits(&buf, 3, cs->data[i][30] >> 5);
+        }
+    }
+    /* finesignatures */
+    put_bits(&buf, 1, 0); /* CompressionFlag, only 0 supported */
+    for (fs = sc->finesiglist; fs; fs = fs->next) {
+        put_bits(&buf, 1, 1); /* MediaTimeFlagOfFrame */
+        put_bits32(&buf, 0xFFFFFFFF & fs->pts); /* MediaTimeOfFrame */
+        put_bits(&buf, 8, fs->confidence); /* FrameConfidence */
+        for (i = 0; i < 5; i++) {
+            put_bits(&buf, 8, fs->words[i]); /* Words */
+        }
+        /* framesignature */
+        for (i = 0; i < SIGELEM_SIZE/5; i++) {
+            put_bits(&buf, 8, fs->framesig[i]);
+        }
+    }
+
+    flush_put_bits(&buf);
+    fwrite(buffer, 1, put_bits_count(&buf)/8, f);
+    fclose(f);
+    av_freep(&buffer);
+    return 0;
+}
+
+static int calc_signature(AVFilterContext *ctx, StreamContext *sc, FineSignature* fs, uint64_t intpic[32][32], int64_t denom, int64_t precfactor)
+{
+    int i, j, k, ternary;
+    uint64_t blocksum;
+    int blocksize;
+    int64_t th; /* threshold */
+    int64_t sum;
+    uint64_t conflist[DIFFELEM_SIZE];
+    int f = 0, g = 0, w = 0;
+        static const uint8_t pot3[5] = { 3*3*3*3, 3*3*3, 3*3, 3, 1 };
+    /* indexes of words : 210,217,219,274,334  44,175,233,270,273  57,70,103,237,269  100,285,295,337,354  101,102,111,275,296
+    s2usw = sorted to unsorted wordvec: 44 is at index 5, 57 at index 10...
+    */
+    static const unsigned int wordvec[25] = {44,57,70,100,101,102,103,111,175,210,217,219,233,237,269,270,273,274,275,285,295,296,334,337,354};
+    static const uint8_t      s2usw[25]   = { 5,10,11, 15, 20, 21, 12, 22,  6,  0,  1,  2,  7, 13, 14,  8,  9,  3, 23, 16, 17, 24,  4, 18, 19};
+
+    uint8_t wordt2b[5] = { 0, 0, 0, 0, 0 }; /* word ternary to binary */
+    for (i = 0; i < ELEMENT_COUNT; i++) {
+        const ElemCat* elemcat = elements[i];
+        int64_t* elemsignature;
+        uint64_t* sortsignature;
+
+        elemsignature = av_malloc_array(elemcat->elem_count, sizeof(int64_t));
+        if (!elemsignature)
+            return AVERROR(ENOMEM);
+        sortsignature = av_malloc_array(elemcat->elem_count, sizeof(int64_t));
+        if (!sortsignature) {
+            av_freep(&elemsignature);
+            return AVERROR(ENOMEM);
+        }
+
+        for (j = 0; j < elemcat->elem_count; j++) {
+            blocksum = 0;
+            blocksize = 0;
+            for (k = 0; k < elemcat->left_count; k++) {
+                blocksum += get_block_sum(sc, intpic, &elemcat->blocks[j*elemcat->block_count+k]);
+                blocksize += get_block_size(&elemcat->blocks[j*elemcat->block_count+k]);
+            }
+            sum = blocksum / blocksize;
+            if (elemcat->av_elem) {
+                sum -= 128 * precfactor * denom;
+            } else {
+                blocksum = 0;
+                blocksize = 0;
+                for (; k < elemcat->block_count; k++) {
+                    blocksum += get_block_sum(sc, intpic, &elemcat->blocks[j*elemcat->block_count+k]);
+                    blocksize += get_block_size(&elemcat->blocks[j*elemcat->block_count+k]);
+                }
+                sum -= blocksum / blocksize;
+                conflist[g++] = FFABS(sum * 8 / (precfactor * denom));
+            }
+
+            elemsignature[j] = sum;
+            sortsignature[j] = FFABS(sum);
+        }
+
+        /* get threshold */
+        qsort(sortsignature, elemcat->elem_count, sizeof(uint64_t), cmp);
+        th = sortsignature[(int) (elemcat->elem_count*0.333)];
+
+        /* ternarize */
+        for (j = 0; j < elemcat->elem_count; j++) {
+            if (elemsignature[j] < -th) {
+                ternary = 0;
+            } else if (elemsignature[j] <= th) {
+                ternary = 1;
+            } else {
+                ternary = 2;
+            }
+            fs->framesig[f/5] += ternary * pot3[f%5];
+
+            if (f == wordvec[w]) {
+                fs->words[s2usw[w]/5] += ternary * pot3[wordt2b[s2usw[w]/5]++];
+                if (w < 24)
+                    w++;
+            }
+            f++;
+        }
+        av_freep(&elemsignature);
+        av_freep(&sortsignature);
+    }
+
+    /* confidence */
+    qsort(conflist, DIFFELEM_SIZE, sizeof(uint64_t), cmp);
+    fs->confidence = FFMIN(conflist[DIFFELEM_SIZE/2], 255);
+
+    /* coarsesignature */
+    if (sc->coarsecount == 0) {
+        if (sc->curcoarsesig2) {
+            sc->curcoarsesig1 = av_mallocz(sizeof(CoarseSignature));
+            if (!sc->curcoarsesig1)
+                return AVERROR(ENOMEM);
+            sc->curcoarsesig1->first = fs;
+            sc->curcoarsesig2->next = sc->curcoarsesig1;
+            sc->coarseend = sc->curcoarsesig1;
+        }
+    }
+    if (sc->coarsecount == 45) {
+        sc->midcoarse = 1;
+        sc->curcoarsesig2 = av_mallocz(sizeof(CoarseSignature));
+        if (!sc->curcoarsesig2)
+            return AVERROR(ENOMEM);
+        sc->curcoarsesig2->first = fs;
+        sc->curcoarsesig1->next = sc->curcoarsesig2;
+        sc->coarseend = sc->curcoarsesig2;
+    }
+    for (i = 0; i < 5; i++) {
+        set_bit(sc->curcoarsesig1->data[i], fs->words[i]);
+    }
+    /* assuming the actual frame is the last */
+    sc->curcoarsesig1->last = fs;
+    if (sc->midcoarse) {
+        for (i = 0; i < 5; i++) {
+            set_bit(sc->curcoarsesig2->data[i], fs->words[i]);
+        }
+        sc->curcoarsesig2->last = fs;
+    }
+
+    sc->coarsecount = (sc->coarsecount+1)%90;
+
+    /* debug printing finesignature */
+    if (av_log_get_level() == AV_LOG_DEBUG) {
+        av_log(ctx, AV_LOG_DEBUG, "input %d, confidence: %d\n", 0, fs->confidence);
+
+        av_log(ctx, AV_LOG_DEBUG, "words:");
+        for (i = 0; i < 5; i++) {
+            av_log(ctx, AV_LOG_DEBUG, " %d:", fs->words[i] );
+            av_log(ctx, AV_LOG_DEBUG, " %d", fs->words[i] / pot3[0] );
+            for (j = 1; j < 5; j++)
+                av_log(ctx, AV_LOG_DEBUG, ",%d", fs->words[i] % pot3[j-1] / pot3[j] );
+            av_log(ctx, AV_LOG_DEBUG, ";");
+        }
+        av_log(ctx, AV_LOG_DEBUG, "\n");
+
+        av_log(ctx, AV_LOG_DEBUG, "framesignature:");
+        for (i = 0; i < SIGELEM_SIZE/5; i++) {
+            av_log(ctx, AV_LOG_DEBUG, " %d", fs->framesig[i] / pot3[0] );
+            for (j = 1; j < 5; j++)
+                av_log(ctx, AV_LOG_DEBUG, ",%d", fs->framesig[i] % pot3[j-1] / pot3[j] );
+        }
+        av_log(ctx, AV_LOG_DEBUG, "\n");
+    }
+
+    return 0;
 }

--- a/libavfilter/vf_signature.c
+++ b/libavfilter/vf_signature.c
@@ -25,6 +25,7 @@
  */
 
 #include "libavcodec/put_bits.h"
+#include "libavcodec/get_bits.h"
 #include "libavformat/avformat.h"
 #include "libavutil/opt.h"
 #include "libavutil/avstring.h"
@@ -37,6 +38,16 @@
 #define OFFSET(x) offsetof(SignatureContext, x)
 #define FLAGS AV_OPT_FLAG_FILTERING_PARAM | AV_OPT_FLAG_VIDEO_PARAM
 #define BLOCK_LCM (int64_t) 476985600
+#define INPUTS_COUNT 2
+#define MPEG7_FINESIG_NBITS 689
+
+typedef struct BoundedCoarseSignature {
+    // StartFrameOfSegment and EndFrameOfSegment
+    uint32_t firstIndex, lastIndex;
+    // StartMediaTimeOfSegment and EndMediaTimeOfSegment
+    uint64_t firstPts, lastPts;
+    CoarseSignature *cSign;
+} BoundedCoarseSignature;
 
 static const AVOption signature_options[] = {
     { "detectmode", "set the detectmode",
@@ -97,49 +108,6 @@ static int config_input(AVFilterLink *inlink)
     return 0;
 }
 
-static int get_block_size(const Block *b)
-{
-    return (b->to.y - b->up.y + 1) * (b->to.x - b->up.x + 1);
-}
-
-static uint64_t get_block_sum(StreamContext *sc, uint64_t intpic[32][32], const Block *b)
-{
-    uint64_t sum = 0;
-
-    int x0, y0, x1, y1;
-
-    x0 = b->up.x;
-    y0 = b->up.y;
-    x1 = b->to.x;
-    y1 = b->to.y;
-
-    if (x0-1 >= 0 && y0-1 >= 0) {
-        sum = intpic[y1][x1] + intpic[y0-1][x0-1] - intpic[y1][x0-1] - intpic[y0-1][x1];
-    } else if (x0-1 >= 0) {
-        sum = intpic[y1][x1] - intpic[y1][x0-1];
-    } else if (y0-1 >= 0) {
-        sum = intpic[y1][x1] - intpic[y0-1][x1];
-    } else {
-        sum = intpic[y1][x1];
-    }
-    return sum;
-}
-
-static int cmp(const void *x, const void *y)
-{
-    const uint64_t *a = x, *b = y;
-    return *a < *b ? -1 : ( *a > *b ? 1 : 0 );
-}
-
-/**
- * sets the bit at position pos to 1 in data
- */
-static void set_bit(uint8_t* data, size_t pos)
-{
-    uint8_t mask = 1 << 7-(pos%8);
-    data[pos/8] |= mask;
-}
-
 static int filter_frame(AVFilterLink *inlink, AVFrame *picref)
 {
     AVFilterContext *ctx = inlink->dst;
@@ -147,29 +115,15 @@ static int filter_frame(AVFilterLink *inlink, AVFrame *picref)
     StreamContext *sc = &(sic->streamcontexts[FF_INLINK_IDX(inlink)]);
     FineSignature* fs;
 
-    static const uint8_t pot3[5] = { 3*3*3*3, 3*3*3, 3*3, 3, 1 };
-    /* indexes of words : 210,217,219,274,334  44,175,233,270,273  57,70,103,237,269  100,285,295,337,354  101,102,111,275,296
-    s2usw = sorted to unsorted wordvec: 44 is at index 5, 57 at index 10...
-    */
-    static const unsigned int wordvec[25] = {44,57,70,100,101,102,103,111,175,210,217,219,233,237,269,270,273,274,275,285,295,296,334,337,354};
-    static const uint8_t      s2usw[25]   = { 5,10,11, 15, 20, 21, 12, 22,  6,  0,  1,  2,  7, 13, 14,  8,  9,  3, 23, 16, 17, 24,  4, 18, 19};
-
-    uint8_t wordt2b[5] = { 0, 0, 0, 0, 0 }; /* word ternary to binary */
     uint64_t intpic[32][32];
     uint64_t rowcount;
     uint8_t *p = picref->data[0];
     int inti, intj;
     int *intjlut;
+    int i, j, ret;
 
-    uint64_t conflist[DIFFELEM_SIZE];
-    int f = 0, g = 0, w = 0;
     int32_t dh1 = 1, dh2 = 1, dw1 = 1, dw2 = 1, a, b;
     int64_t denom;
-    int i, j, k, ternary;
-    uint64_t blocksum;
-    int blocksize;
-    int64_t th; /* threshold */
-    int64_t sum;
 
     int64_t precfactor = (sc->divide) ? 65536 : BLOCK_LCM;
 
@@ -244,320 +198,12 @@ static int filter_frame(AVFilterLink *inlink, AVFrame *picref)
     }
 
     denom = (sc->divide) ? 1 : dh1 * (int64_t)dh2 * dw1 * dw2;
-
-    for (i = 0; i < ELEMENT_COUNT; i++) {
-        const ElemCat* elemcat = elements[i];
-        int64_t* elemsignature;
-        uint64_t* sortsignature;
-
-        elemsignature = av_malloc_array(elemcat->elem_count, sizeof(int64_t));
-        if (!elemsignature)
-            return AVERROR(ENOMEM);
-        sortsignature = av_malloc_array(elemcat->elem_count, sizeof(int64_t));
-        if (!sortsignature) {
-            av_freep(&elemsignature);
-            return AVERROR(ENOMEM);
-        }
-
-        for (j = 0; j < elemcat->elem_count; j++) {
-            blocksum = 0;
-            blocksize = 0;
-            for (k = 0; k < elemcat->left_count; k++) {
-                blocksum += get_block_sum(sc, intpic, &elemcat->blocks[j*elemcat->block_count+k]);
-                blocksize += get_block_size(&elemcat->blocks[j*elemcat->block_count+k]);
-            }
-            sum = blocksum / blocksize;
-            if (elemcat->av_elem) {
-                sum -= 128 * precfactor * denom;
-            } else {
-                blocksum = 0;
-                blocksize = 0;
-                for (; k < elemcat->block_count; k++) {
-                    blocksum += get_block_sum(sc, intpic, &elemcat->blocks[j*elemcat->block_count+k]);
-                    blocksize += get_block_size(&elemcat->blocks[j*elemcat->block_count+k]);
-                }
-                sum -= blocksum / blocksize;
-                conflist[g++] = FFABS(sum * 8 / (precfactor * denom));
-            }
-
-            elemsignature[j] = sum;
-            sortsignature[j] = FFABS(sum);
-        }
-
-        /* get threshold */
-        qsort(sortsignature, elemcat->elem_count, sizeof(uint64_t), cmp);
-        th = sortsignature[(int) (elemcat->elem_count*0.333)];
-
-        /* ternarize */
-        for (j = 0; j < elemcat->elem_count; j++) {
-            if (elemsignature[j] < -th) {
-                ternary = 0;
-            } else if (elemsignature[j] <= th) {
-                ternary = 1;
-            } else {
-                ternary = 2;
-            }
-            fs->framesig[f/5] += ternary * pot3[f%5];
-
-            if (f == wordvec[w]) {
-                fs->words[s2usw[w]/5] += ternary * pot3[wordt2b[s2usw[w]/5]++];
-                if (w < 24)
-                    w++;
-            }
-            f++;
-        }
-        av_freep(&elemsignature);
-        av_freep(&sortsignature);
-    }
-
-    /* confidence */
-    qsort(conflist, DIFFELEM_SIZE, sizeof(uint64_t), cmp);
-    fs->confidence = FFMIN(conflist[DIFFELEM_SIZE/2], 255);
-
-    /* coarsesignature */
-    if (sc->coarsecount == 0) {
-        if (sc->curcoarsesig2) {
-            sc->curcoarsesig1 = av_mallocz(sizeof(CoarseSignature));
-            if (!sc->curcoarsesig1)
-                return AVERROR(ENOMEM);
-            sc->curcoarsesig1->first = fs;
-            sc->curcoarsesig2->next = sc->curcoarsesig1;
-            sc->coarseend = sc->curcoarsesig1;
-        }
-    }
-    if (sc->coarsecount == 45) {
-        sc->midcoarse = 1;
-        sc->curcoarsesig2 = av_mallocz(sizeof(CoarseSignature));
-        if (!sc->curcoarsesig2)
-            return AVERROR(ENOMEM);
-        sc->curcoarsesig2->first = fs;
-        sc->curcoarsesig1->next = sc->curcoarsesig2;
-        sc->coarseend = sc->curcoarsesig2;
-    }
-    for (i = 0; i < 5; i++) {
-        set_bit(sc->curcoarsesig1->data[i], fs->words[i]);
-    }
-    /* assuming the actual frame is the last */
-    sc->curcoarsesig1->last = fs;
-    if (sc->midcoarse) {
-        for (i = 0; i < 5; i++) {
-            set_bit(sc->curcoarsesig2->data[i], fs->words[i]);
-        }
-        sc->curcoarsesig2->last = fs;
-    }
-
-    sc->coarsecount = (sc->coarsecount+1)%90;
-
-    /* debug printing finesignature */
-    if (av_log_get_level() == AV_LOG_DEBUG) {
-        av_log(ctx, AV_LOG_DEBUG, "input %d, confidence: %d\n", FF_INLINK_IDX(inlink), fs->confidence);
-
-        av_log(ctx, AV_LOG_DEBUG, "words:");
-        for (i = 0; i < 5; i++) {
-            av_log(ctx, AV_LOG_DEBUG, " %d:", fs->words[i] );
-            av_log(ctx, AV_LOG_DEBUG, " %d", fs->words[i] / pot3[0] );
-            for (j = 1; j < 5; j++)
-                av_log(ctx, AV_LOG_DEBUG, ",%d", fs->words[i] % pot3[j-1] / pot3[j] );
-            av_log(ctx, AV_LOG_DEBUG, ";");
-        }
-        av_log(ctx, AV_LOG_DEBUG, "\n");
-
-        av_log(ctx, AV_LOG_DEBUG, "framesignature:");
-        for (i = 0; i < SIGELEM_SIZE/5; i++) {
-            av_log(ctx, AV_LOG_DEBUG, " %d", fs->framesig[i] / pot3[0] );
-            for (j = 1; j < 5; j++)
-                av_log(ctx, AV_LOG_DEBUG, ",%d", fs->framesig[i] % pot3[j-1] / pot3[j] );
-        }
-        av_log(ctx, AV_LOG_DEBUG, "\n");
-    }
+    ret = calc_signature(ctx, sc, fs, intpic, denom, precfactor);
+    if (ret < 0) return ret;
 
     if (FF_INLINK_IDX(inlink) == 0)
         return ff_filter_frame(inlink->dst->outputs[0], picref);
     return 1;
-}
-
-static int xml_export(AVFilterContext *ctx, StreamContext *sc, const char* filename)
-{
-    FineSignature* fs;
-    CoarseSignature* cs;
-    int i, j;
-    FILE* f;
-    unsigned int pot3[5] = { 3*3*3*3, 3*3*3, 3*3, 3, 1 };
-
-    f = avpriv_fopen_utf8(filename, "w");
-    if (!f) {
-        int err = AVERROR(EINVAL);
-        char buf[128];
-        av_strerror(err, buf, sizeof(buf));
-        av_log(ctx, AV_LOG_ERROR, "cannot open xml file %s: %s\n", filename, buf);
-        return err;
-    }
-
-    /* header */
-    fprintf(f, "<?xml version='1.0' encoding='ASCII' ?>\n");
-    fprintf(f, "<Mpeg7 xmlns=\"urn:mpeg:mpeg7:schema:2001\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:schemaLocation=\"urn:mpeg:mpeg7:schema:2001 schema/Mpeg7-2001.xsd\">\n");
-    fprintf(f, "  <DescriptionUnit xsi:type=\"DescriptorCollectionType\">\n");
-    fprintf(f, "    <Descriptor xsi:type=\"VideoSignatureType\">\n");
-    fprintf(f, "      <VideoSignatureRegion>\n");
-    fprintf(f, "        <VideoSignatureSpatialRegion>\n");
-    fprintf(f, "          <Pixel>0 0 </Pixel>\n");
-    fprintf(f, "          <Pixel>%d %d </Pixel>\n", sc->w - 1, sc->h - 1);
-    fprintf(f, "        </VideoSignatureSpatialRegion>\n");
-    fprintf(f, "        <StartFrameOfSpatialRegion>0</StartFrameOfSpatialRegion>\n");
-    /* hoping num is 1, other values are vague */
-    fprintf(f, "        <MediaTimeUnit>%d</MediaTimeUnit>\n", sc->time_base.den / sc->time_base.num);
-    fprintf(f, "        <MediaTimeOfSpatialRegion>\n");
-    fprintf(f, "          <StartMediaTimeOfSpatialRegion>0</StartMediaTimeOfSpatialRegion>\n");
-    fprintf(f, "          <EndMediaTimeOfSpatialRegion>%" PRIu64 "</EndMediaTimeOfSpatialRegion>\n", sc->coarseend->last->pts);
-    fprintf(f, "        </MediaTimeOfSpatialRegion>\n");
-
-    /* coarsesignatures */
-    for (cs = sc->coarsesiglist; cs; cs = cs->next) {
-        fprintf(f, "        <VSVideoSegment>\n");
-        fprintf(f, "          <StartFrameOfSegment>%" PRIu32 "</StartFrameOfSegment>\n", cs->first->index);
-        fprintf(f, "          <EndFrameOfSegment>%" PRIu32 "</EndFrameOfSegment>\n", cs->last->index);
-        fprintf(f, "          <MediaTimeOfSegment>\n");
-        fprintf(f, "            <StartMediaTimeOfSegment>%" PRIu64 "</StartMediaTimeOfSegment>\n", cs->first->pts);
-        fprintf(f, "            <EndMediaTimeOfSegment>%" PRIu64 "</EndMediaTimeOfSegment>\n", cs->last->pts);
-        fprintf(f, "          </MediaTimeOfSegment>\n");
-        for (i = 0; i < 5; i++) {
-            fprintf(f, "          <BagOfWords>");
-            for (j = 0; j < 31; j++) {
-                uint8_t n = cs->data[i][j];
-                if (j < 30) {
-                    fprintf(f, "%d  %d  %d  %d  %d  %d  %d  %d  ", (n & 0x80) >> 7,
-                                                                   (n & 0x40) >> 6,
-                                                                   (n & 0x20) >> 5,
-                                                                   (n & 0x10) >> 4,
-                                                                   (n & 0x08) >> 3,
-                                                                   (n & 0x04) >> 2,
-                                                                   (n & 0x02) >> 1,
-                                                                   (n & 0x01));
-                } else {
-                    /* print only 3 bit in last byte */
-                    fprintf(f, "%d  %d  %d ", (n & 0x80) >> 7,
-                                              (n & 0x40) >> 6,
-                                              (n & 0x20) >> 5);
-                }
-            }
-            fprintf(f, "</BagOfWords>\n");
-        }
-        fprintf(f, "        </VSVideoSegment>\n");
-    }
-
-    /* finesignatures */
-    for (fs = sc->finesiglist; fs; fs = fs->next) {
-        fprintf(f, "        <VideoFrame>\n");
-        fprintf(f, "          <MediaTimeOfFrame>%" PRIu64 "</MediaTimeOfFrame>\n", fs->pts);
-        /* confidence */
-        fprintf(f, "          <FrameConfidence>%d</FrameConfidence>\n", fs->confidence);
-        /* words */
-        fprintf(f, "          <Word>");
-        for (i = 0; i < 5; i++) {
-            fprintf(f, "%d ", fs->words[i]);
-            if (i < 4) {
-                fprintf(f, " ");
-            }
-        }
-        fprintf(f, "</Word>\n");
-        /* framesignature */
-        fprintf(f, "          <FrameSignature>");
-        for (i = 0; i< SIGELEM_SIZE/5; i++) {
-            if (i > 0) {
-                fprintf(f, " ");
-            }
-            fprintf(f, "%d ", fs->framesig[i] / pot3[0]);
-            for (j = 1; j < 5; j++)
-                fprintf(f, " %d ", fs->framesig[i] % pot3[j-1] / pot3[j] );
-        }
-        fprintf(f, "</FrameSignature>\n");
-        fprintf(f, "        </VideoFrame>\n");
-    }
-    fprintf(f, "      </VideoSignatureRegion>\n");
-    fprintf(f, "    </Descriptor>\n");
-    fprintf(f, "  </DescriptionUnit>\n");
-    fprintf(f, "</Mpeg7>\n");
-
-    fclose(f);
-    return 0;
-}
-
-static int binary_export(AVFilterContext *ctx, StreamContext *sc, const char* filename)
-{
-    FILE* f;
-    FineSignature* fs;
-    CoarseSignature* cs;
-    uint32_t numofsegments = (sc->lastindex + 44)/45;
-    int i, j;
-    PutBitContext buf;
-    /* buffer + header + coarsesignatures + finesignature */
-    int len = (512 + 6 * 32 + 3*16 + 2 +
-        numofsegments * (4*32 + 1 + 5*243) +
-        sc->lastindex * (2 + 32 + 6*8 + 608)) / 8;
-    uint8_t* buffer = av_malloc_array(len, sizeof(uint8_t));
-    if (!buffer)
-        return AVERROR(ENOMEM);
-
-    f = avpriv_fopen_utf8(filename, "wb");
-    if (!f) {
-        int err = AVERROR(EINVAL);
-        char buf[128];
-        av_strerror(err, buf, sizeof(buf));
-        av_log(ctx, AV_LOG_ERROR, "cannot open file %s: %s\n", filename, buf);
-        av_freep(&buffer);
-        return err;
-    }
-    init_put_bits(&buf, buffer, len);
-
-    put_bits32(&buf, 1); /* NumOfSpatial Regions, only 1 supported */
-    put_bits(&buf, 1, 1); /* SpatialLocationFlag, always the whole image */
-    put_bits32(&buf, 0); /* PixelX,1 PixelY,1, 0,0 */
-    put_bits(&buf, 16, sc->w-1 & 0xFFFF); /* PixelX,2 */
-    put_bits(&buf, 16, sc->h-1 & 0xFFFF); /* PixelY,2 */
-    put_bits32(&buf, 0); /* StartFrameOfSpatialRegion */
-    put_bits32(&buf, sc->lastindex); /* NumOfFrames */
-    /* hoping num is 1, other values are vague */
-    /* den/num might be greater than 16 bit, so cutting it */
-    put_bits(&buf, 16, 0xFFFF & (sc->time_base.den / sc->time_base.num)); /* MediaTimeUnit */
-    put_bits(&buf, 1, 1); /* MediaTimeFlagOfSpatialRegion */
-    put_bits32(&buf, 0); /* StartMediaTimeOfSpatialRegion */
-    put_bits32(&buf, 0xFFFFFFFF & sc->coarseend->last->pts); /* EndMediaTimeOfSpatialRegion */
-    put_bits32(&buf, numofsegments); /* NumOfSegments */
-    /* coarsesignatures */
-    for (cs = sc->coarsesiglist; cs; cs = cs->next) {
-        put_bits32(&buf, cs->first->index); /* StartFrameOfSegment */
-        put_bits32(&buf, cs->last->index); /* EndFrameOfSegment */
-        put_bits(&buf, 1, 1); /* MediaTimeFlagOfSegment */
-        put_bits32(&buf, 0xFFFFFFFF & cs->first->pts); /* StartMediaTimeOfSegment */
-        put_bits32(&buf, 0xFFFFFFFF & cs->last->pts); /* EndMediaTimeOfSegment */
-        for (i = 0; i < 5; i++) {
-            /* put 243 bits ( = 7 * 32 + 19 = 8 * 28 + 19) into buffer */
-            for (j = 0; j < 30; j++) {
-                put_bits(&buf, 8, cs->data[i][j]);
-            }
-            put_bits(&buf, 3, cs->data[i][30] >> 5);
-        }
-    }
-    /* finesignatures */
-    put_bits(&buf, 1, 0); /* CompressionFlag, only 0 supported */
-    for (fs = sc->finesiglist; fs; fs = fs->next) {
-        put_bits(&buf, 1, 1); /* MediaTimeFlagOfFrame */
-        put_bits32(&buf, 0xFFFFFFFF & fs->pts); /* MediaTimeOfFrame */
-        put_bits(&buf, 8, fs->confidence); /* FrameConfidence */
-        for (i = 0; i < 5; i++) {
-            put_bits(&buf, 8, fs->words[i]); /* Words */
-        }
-        /* framesignature */
-        for (i = 0; i < SIGELEM_SIZE/5; i++) {
-            put_bits(&buf, 8, fs->framesig[i]);
-        }
-    }
-
-    flush_put_bits(&buf);
-    fwrite(buffer, 1, put_bytes_output(&buf), f);
-    fclose(f);
-    av_freep(&buffer);
-    return 0;
 }
 
 static int export(AVFilterContext *ctx, StreamContext *sc, int input)
@@ -735,6 +381,355 @@ static int config_output(AVFilterLink *outlink)
     outlink->h = inlink->h;
 
     return 0;
+}
+
+static void release_streamcontext(StreamContext *sc)
+{
+    free(sc->coarsesiglist);
+    free(sc->finesiglist);
+}
+
+static int get_filesize(const char *filename)
+{
+    int fileLength = 0;
+    FILE *f = NULL;
+    f = fopen(filename, "rb");
+    if(f != NULL) {
+        fseek(f, 0, SEEK_END);
+        fileLength = ftell(f);
+        fclose(f);
+    }
+    return fileLength;
+}
+
+static uint8_t * get_filebuffer(const char *filename, int* fileLength)
+{
+    FILE *f = NULL;
+    unsigned int readLength, paddedLength = 0;
+    uint8_t *buffer = NULL;
+
+    //check input parameters
+    if (strlen(filename) <= 0) return buffer;
+    f = fopen(filename, "rb");
+    if (f == NULL) {
+        av_log(NULL, AV_LOG_ERROR, "Could not open the file %s\n", filename);
+        return buffer;
+    }
+    *fileLength = get_filesize(filename);
+    if(*fileLength > 0) {
+        // Cast to float is necessary to avoid int division
+        paddedLength = ceil(*fileLength / (float)AV_INPUT_BUFFER_PADDING_SIZE)*AV_INPUT_BUFFER_PADDING_SIZE + AV_INPUT_BUFFER_PADDING_SIZE;
+        buffer = (uint8_t*)av_calloc(paddedLength, sizeof(uint8_t));
+        if (!buffer) {
+            av_log(NULL, AV_LOG_ERROR, "Could not allocate memory for reading signature file\n");
+            fclose(f);
+            return NULL;
+        }
+        // Read entire file into memory
+        readLength = fread(buffer, sizeof(uint8_t), *fileLength, f);
+        if(readLength != *fileLength) {
+            av_log(NULL, AV_LOG_ERROR, "Could not read the file %s\n", filename);
+            free(buffer);
+            buffer = NULL;
+        }
+    }
+    fclose(f);
+    return buffer;
+}
+
+static int binary_import(uint8_t *buffer, int fileLength, StreamContext *sc)
+{
+    int ret = 0;
+
+    unsigned int numOfSegments = 0;
+    GetBitContext bitContext = { 0 };
+    BoundedCoarseSignature *bCs;
+    unsigned int i, j, k;
+    int totalLength = 8 * fileLength;
+    int finesigncount = 0;
+    BoundedCoarseSignature *bCoarseList;
+
+    if (init_get_bits(&bitContext, buffer, totalLength)) {
+        return -1;
+    }
+
+    // Skip the following data:
+    // - NumOfSpatial Regions: (32 bits) only 1 supported
+    // - SpatialLocationFlag: (1 bit) always the whole image
+    // - PixelX_1: (16 bits) always 0
+    // - PixelY_1: (16 bits) always 0
+    skip_bits(&bitContext, 32 + 1 + 16 * 2);
+
+    // width - 1, and height - 1
+    // PixelX_2: (16 bits) is width - 1
+    // PixelY_2: (16 bits) is height - 1
+    sc->w = get_bits(&bitContext, 16);
+    sc->h = get_bits(&bitContext, 16);
+    ++sc->w;
+    ++sc->h;
+
+    // StartFrameOfSpatialRegion, always 0
+    skip_bits(&bitContext, 32);
+
+    // NumOfFrames
+    // it's the number of fine signatures
+    sc->lastindex = get_bits_long(&bitContext, 32);
+
+    // MediaTimeUnit
+    // sc->time_base.den / sc->time_base.num
+    // hoping num is 1, other values are vague
+    // den/num might be greater than 16 bit, so cutting it
+    //put_bits(&buf, 16, 0xFFFF & (sc->time_base.den / sc->time_base.num));
+
+    sc->time_base.den = get_bits(&bitContext, 16);
+    sc->time_base.num = 1;
+
+    // Skip the following data
+    // - MediaTimeFlagOfSpatialRegion: (1 bit) always 1
+    // - StartMediaTimeOfSpatialRegion: (32 bits) always 0
+    // - EndMediaTimeOfSpatialRegion: (32 bits)
+    skip_bits(&bitContext, 1 + 32*2);
+
+    // Coarse signatures
+    // numOfSegments = number of coarse signatures
+    numOfSegments = get_bits_long(&bitContext, 32);
+    if (numOfSegments <= 0) {
+        return -1;
+    }
+
+    sc->coarsesiglist = (CoarseSignature*)av_calloc(numOfSegments, sizeof(CoarseSignature));
+    if(sc->coarsesiglist == NULL) {
+        return AVERROR(ENOMEM);
+    }
+
+    bCoarseList = (BoundedCoarseSignature*)av_calloc(numOfSegments, sizeof(BoundedCoarseSignature));
+    if(bCoarseList == NULL) {
+        av_freep(&sc->coarsesiglist);
+        return AVERROR(ENOMEM);
+    }
+
+    // CoarseSignature loading
+    for (i = 0; i < numOfSegments; ++i) {
+        bCs = &bCoarseList[i];
+        bCs->cSign = &sc->coarsesiglist[i];
+
+        if (i < numOfSegments - 1)
+            bCs->cSign->next = &sc->coarsesiglist[i + 1];
+        // each coarse signature is a VSVideoSegment
+        // StartFrameOfSegment
+        bCs->firstIndex = get_bits_long(&bitContext, 32);
+        // EndFrameOfSegment
+        bCs->lastIndex = get_bits_long(&bitContext, 32);
+
+        // MediaTimeFlagOfSegment 1 bit, always 1
+        skip_bits(&bitContext, 1);
+
+        // Fine signature pts
+        // StartMediaTimeOfSegment 32 bits
+        bCs->firstPts = get_bits_long(&bitContext, 32);
+        // EndMediaTimeOfSegment 32 bits
+        bCs->lastPts = get_bits_long(&bitContext, 32);
+        // Bag of words
+        for ( j = 0; j < 5; ++j) {
+            // read 243 bits ( = 7 * 32 + 19 = 8 * 28 + 19) into buffer
+            for ( k = 0; k < 30; ++k) {
+                // 30*8 bits = 30 bytes
+                bCs->cSign->data[j][k] = get_bits(&bitContext, 8);
+            }
+            bCs->cSign->data[j][30] = get_bits(&bitContext, 3) << 5;
+        }
+        //check remain bit
+        if(totalLength - bitContext.index <= 0) {
+            av_freep(&sc->coarsesiglist);
+            av_free(bCoarseList);
+            return -1;
+        }
+    }
+    sc->coarseend = &sc->coarsesiglist[numOfSegments - 1];
+
+    // Finesignatures
+    // CompressionFlag, only 0 supported
+    skip_bits(&bitContext, 1);
+
+
+    // Check lastindex for validity
+    finesigncount = (totalLength - bitContext.index) / MPEG7_FINESIG_NBITS;
+    if (!finesigncount) {
+        av_freep(&sc->coarsesiglist);
+        av_free(bCoarseList);
+        return -1;
+    }
+
+    if(sc->lastindex != finesigncount)
+        sc->lastindex = finesigncount;
+    sc->finesiglist = (FineSignature*)av_calloc(sc->lastindex, sizeof(FineSignature));
+    if(sc->finesiglist == NULL) {
+        av_freep(&sc->coarsesiglist);
+        av_free(bCoarseList);
+        return AVERROR(ENOMEM);
+    }
+
+    // Load fine signatures from file
+    for (i = 0; i < sc->lastindex; ++i) {
+        FineSignature *fs = &sc->finesiglist[i];
+
+        // MediaTimeFlagOfFrame always 1
+        skip_bits(&bitContext, 1);
+
+        // MediaTimeOfFrame (PTS)
+        fs->pts = get_bits_long(&bitContext, 32);
+
+        // FrameConfidence
+        fs->confidence = get_bits(&bitContext, 8);
+
+        // words
+        for (k = 0; k < 5; k++) {
+            fs->words[k] = get_bits(&bitContext, 8);
+        }
+        // framesignature
+        for (k = 0; k < SIGELEM_SIZE / 5; k++) {
+            fs->framesig[k] = get_bits(&bitContext, 8);
+        }
+    }
+
+    // Creating FineSignature linked list
+    for (i = 0; i < sc->lastindex; ++i) {
+        FineSignature *fs = &sc->finesiglist[i];
+        // Building fine signature list
+        // First element prev should be NULL
+        // Last element next should be NULL
+        if (i == 0 && sc->lastindex == 1) {
+            fs->next = NULL;
+            fs->prev = NULL;
+        } else if (i == 0) {
+            fs->next = &fs[1];
+            fs->prev = NULL;
+        }
+        else if (i == sc->lastindex - 1) {
+            fs->next = NULL;
+            fs->prev = &fs[-1];
+        }
+        else {
+            fs->next = &fs[1];
+            fs->prev = &fs[-1];
+        }
+    }
+
+    // Fine signature ranges DO overlap
+    // Assign FineSignatures to CoarseSignatures
+    for (i = 0; i < numOfSegments; ++i) {
+        BoundedCoarseSignature *bCs = &bCoarseList[i];
+        uint64_t firstpts = bCs->firstPts;
+        if (firstpts > bCs->lastPts) {
+            firstpts = bCs->lastPts;
+        }
+        for (j = 0;  j < sc->lastindex; ++j) {
+            FineSignature *fs = &sc->finesiglist[j];
+            if (fs->pts >= firstpts) {
+                // Check if the fragment's pts is inside coarse signature
+                // bounds. Upper bound is checked in for loop
+                if (!bCs->cSign->first) {
+                    bCs->cSign->first = fs;
+                }
+
+                if (bCs->cSign->last) {
+                    if (bCs->cSign->last->pts <= fs->pts)
+                        bCs->cSign->last = fs;
+                } else {
+                    bCs->cSign->last = fs;
+                }
+            }
+        }
+        if(!bCs->cSign->first || !bCs->cSign->last) {
+           ret = -1;
+           break;
+        }
+        bCs->cSign->first->index = bCs->firstIndex;
+        bCs->cSign->last->index = bCs->lastIndex;
+    }
+
+    if(ret < 0) {
+        av_freep(&sc->coarsesiglist);
+    }
+    av_free(bCoarseList);
+
+    return ret;
+}
+
+static int compare_signbuffer(uint8_t* signbuf1, int len1, uint8_t* signbuf2, int len2) {
+    int ret = -1;
+    StreamContext scontexts[INPUTS_COUNT] = { 0 };
+    MatchingInfo result = { 0 };
+    SignatureContext sigContext = {
+        .class = NULL,
+        .mode = MODE_FULL,
+        .nb_inputs = INPUTS_COUNT,
+        .filename = NULL,
+        .thworddist = 9000,
+        .thcomposdist = 60000,
+        .thl1 = 150,
+        .thdi = 0,
+        .thit = 0.5,
+        .streamcontexts = scontexts
+    };
+    if (binary_import(signbuf1, len1, &scontexts[0]) < 0 || binary_import(signbuf2, len2, &scontexts[1]) < 0) {
+        if(scontexts[0].coarsesiglist) {
+            av_freep(&scontexts[0].coarsesiglist);
+        }
+        if(scontexts[1].coarsesiglist) {
+            av_freep(&scontexts[1].coarsesiglist);
+        }
+        av_log(NULL, AV_LOG_ERROR, "Could not create StreamContext from binary data for signature\n");
+        return ret;
+    }
+    result = lookup_signatures(NULL, &sigContext, &scontexts[0], &scontexts[1], MODE_FULL);
+
+    if (result.score != 0) {
+        if (result.whole) ret = 2;//full matching
+        else ret = 1; //partial matching
+    }
+    else {
+        ret = 0; //no matching
+    }
+
+    release_streamcontext(&scontexts[0]);
+    release_streamcontext(&scontexts[1]);
+
+    return ret;
+}
+
+int avfilter_compare_sign_bybuff(uint8_t *signbuf1, int len1, uint8_t *signbuf2, int len2)
+{
+    int ret = -1;
+
+    if(signbuf1 != NULL && signbuf2 != NULL && len1 > 0 && len2 > 0) {
+        ret = compare_signbuffer(signbuf1, len1, signbuf2, len2);
+    }
+
+    return ret;
+}
+
+int avfilter_compare_sign_bypath(char *signpath1, char *signpath2)
+{
+    int ret = -1;
+
+    int len1, len2;
+    uint8_t *buffer1, *buffer2;
+    buffer1 = get_filebuffer(signpath1, &len1);
+    if(buffer1 == NULL) return AVERROR(ENOMEM);
+    buffer2 = get_filebuffer(signpath2, &len2);
+    if(buffer2 == NULL) {
+        free(buffer1);
+        return AVERROR(ENOMEM);
+    }
+    ret = compare_signbuffer(buffer1, len1, buffer2, len2);
+
+    if(buffer1 != NULL)
+        free(buffer1);
+    if(buffer2 != NULL)
+        free(buffer2);
+
+    return ret;
 }
 
 static const AVFilterPad signature_outputs[] = {

--- a/libavfilter/vf_signature_cuda.c
+++ b/libavfilter/vf_signature_cuda.c
@@ -1,0 +1,490 @@
+#include <float.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "libavutil/avstring.h"
+#include "libavutil/common.h"
+#include "libavutil/hwcontext.h"
+#include "libavutil/hwcontext_cuda_internal.h"
+#include "libavutil/cuda_check.h"
+#include "libavutil/internal.h"
+#include "libavutil/opt.h"
+#include "libavutil/pixdesc.h"
+#include "libavcodec/put_bits.h"
+#include "libavcodec/get_bits.h"
+#include "libavformat/avformat.h"
+#include "avfilter.h"
+#include "formats.h"
+#include "internal.h"
+#include "scale_eval.h"
+#include "video.h"
+#include "signature.h"
+#include "signature_lookup.c"
+
+#define DIV_UP(a, b) ( ((a) + (b) - 1) / (b) )
+#define BLOCKX 32
+#define BLOCKY 16
+#define W_SIGN 32
+#define H_SIGN 32
+#define PIXELS_SIGN 1024
+#define BLOCK_LCM (int64_t) 476985600
+#define CHECK_CU(x) FF_CUDA_CHECK_DL(ctx, s->hwctx->internal->cuda_dl, x)
+
+typedef struct CUDASignContext {
+    const AVClass *class;
+
+    char *filename;
+    int  format;
+
+    StreamContext* streamcontexts;
+
+    AVCUDADeviceContext *hwctx;
+    AVBufferRef *frames_ctx;
+    
+    CUmodule    cu_module;
+    CUfunction  cu_func_boxsum;
+    CUstream    cu_stream;
+    
+    CUdeviceptr boxgpubuff;
+    int64_t     *boxcpubuff;
+
+    float param;
+} CUDASignContext;
+
+#define OFFSET(x) offsetof(CUDASignContext, x)
+#define FLAGS (AV_OPT_FLAG_FILTERING_PARAM|AV_OPT_FLAG_VIDEO_PARAM)
+static const AVOption options[] = {
+    { "filename",   "filename for output file",
+        OFFSET(filename), AV_OPT_TYPE_STRING, {.str = ""}, 0, NB_FORMATS-1, FLAGS },
+    { "format",     "set output format",
+        OFFSET(format),       AV_OPT_TYPE_INT, {.i64 = FORMAT_BINARY}, 0, 1, FLAGS , "format" },
+        { "binary", 0, 0, AV_OPT_TYPE_CONST, {.i64=FORMAT_BINARY}, 0, 0, FLAGS, "format" },
+        { "xml",    0, 0, AV_OPT_TYPE_CONST, {.i64=FORMAT_XML},    0, 0, FLAGS, "format" },
+    { NULL },
+};
+
+static const enum AVPixelFormat supported_formats[] = {
+    AV_PIX_FMT_YUV420P,
+    AV_PIX_FMT_NV12,
+    AV_PIX_FMT_YUV444P,
+    AV_PIX_FMT_YUV444P16,
+    AV_PIX_FMT_YUV422P,
+};
+
+static int cudasign_query_formats(AVFilterContext *ctx)
+{
+    static const enum AVPixelFormat pixel_formats[] = {
+        AV_PIX_FMT_CUDA, AV_PIX_FMT_NONE,
+    };
+    AVFilterFormats *pix_fmts = ff_make_format_list(pixel_formats);
+    if (!pix_fmts)
+        return AVERROR(ENOMEM);
+
+    return ff_set_common_formats(ctx, pix_fmts);
+}
+
+static int format_is_supported(enum AVPixelFormat fmt)
+{
+    int i;
+    for (i = 0; i < FF_ARRAY_ELEMS(supported_formats); i++)
+        if (supported_formats[i] == fmt)
+            return 1;
+    return 0;
+}
+
+static AVFrame *get_pass_video_buffer(AVFilterLink *inlink, int w, int h)
+{
+    return ff_null_get_video_buffer(inlink, w, h);
+}
+
+static av_cold int cudasign_config_props(AVFilterLink *outlink)
+{
+    AVFilterContext *ctx = outlink->src;
+    AVFilterLink *inlink = outlink->src->inputs[0];
+    CUDASignContext *s  = ctx->priv;
+    AVHWFramesContext *frames_ctx = (AVHWFramesContext*)inlink->hw_frames_ctx->data;
+    AVCUDADeviceContext *device_hwctx = frames_ctx->device_ctx->hwctx;
+    CUcontext dummy, cuda_ctx = device_hwctx->cuda_ctx;
+    CudaFunctions *cu = device_hwctx->internal->cuda_dl;
+
+    AVHWFramesContext *in_frames_ctx;
+    enum AVPixelFormat in_format;
+    StreamContext *sc;
+
+    extern unsigned char ff_vf_signature_cuda_ptx_data[];
+    int ret;
+
+    s->hwctx = device_hwctx;
+    s->cu_stream = s->hwctx->stream;
+
+    ret = CHECK_CU(cu->cuCtxPushCurrent(cuda_ctx));
+    if (ret < 0)
+        goto fail;
+
+    ret = CHECK_CU(cu->cuModuleLoadData(&s->cu_module, ff_vf_signature_cuda_ptx_data));
+    if (ret < 0)
+        goto fail;
+    
+    ret = CHECK_CU(cu->cuModuleGetFunction(&s->cu_func_boxsum, s->cu_module, "Subsample_Boxsumint64"));
+    if (ret < 0)
+        goto fail;
+
+    ret = CHECK_CU(cu->cuMemAlloc(&s->boxgpubuff, PIXELS_SIGN * sizeof(int64_t)));
+    if (ret < 0)
+        goto fail;
+
+    CHECK_CU(cu->cuCtxPopCurrent(&dummy));
+
+     if (!ctx->inputs[0]->hw_frames_ctx) {
+        av_log(ctx, AV_LOG_ERROR, "No hw context provided on input\n");
+        return AVERROR(EINVAL);
+    }
+    in_frames_ctx = (AVHWFramesContext*)ctx->inputs[0]->hw_frames_ctx->data;
+    in_format     = in_frames_ctx->sw_format;    
+
+    if (!format_is_supported(in_format)) {
+        av_log(ctx, AV_LOG_ERROR, "Unsupported input format: %s\n",
+               av_get_pix_fmt_name(in_format));
+        return AVERROR(ENOSYS);
+    }
+
+    //for passthrough frame
+    s->frames_ctx = av_buffer_ref(ctx->inputs[0]->hw_frames_ctx);
+    ctx->outputs[0]->hw_frames_ctx = av_buffer_ref(s->frames_ctx);
+    if (!ctx->outputs[0]->hw_frames_ctx)
+        return AVERROR(ENOMEM);
+
+    //config init
+    sc = s->streamcontexts;
+
+    sc->time_base = inlink->time_base;
+    /* test for overflow */
+    sc->divide = (((uint64_t) inlink->w/32) * (inlink->w/32 + 1) * (inlink->h/32 * inlink->h/32 + 1) > INT64_MAX / (BLOCK_LCM * 255));
+    if (sc->divide) {
+        av_log(ctx, AV_LOG_WARNING, "Input dimension too high for precise calculation, numbers will be rounded.\n");
+    }
+    sc->w = inlink->w;
+    sc->h = inlink->h;
+
+    return 0;
+
+fail:
+    return ret;
+}
+
+static int call_boxsum_kernel(AVFilterContext *ctx, CUfunction func, int channels,
+                              uint8_t *src_dptr, int src_width, int src_height, int src_pitch,
+                              uint8_t *dst_dptr, int dst_width, int dst_height, int dst_pitch,
+                              int pixel_size, int bit_depth)
+{
+    CUDASignContext *s = ctx->priv;
+    CudaFunctions *cu = s->hwctx->internal->cuda_dl;
+    CUdeviceptr dst_devptr = (CUdeviceptr)dst_dptr;
+    CUtexObject tex = 0;
+    void *args_uchar[] = { &tex, &dst_devptr, &dst_width, &dst_height, &dst_pitch,
+                           &src_width, &src_height, &bit_depth, &s->param };
+    int ret;
+
+    CUDA_TEXTURE_DESC tex_desc = {
+        .filterMode =  CU_TR_FILTER_MODE_POINT,
+        .flags = CU_TRSF_READ_AS_INTEGER,
+    };
+
+    CUDA_RESOURCE_DESC res_desc = {
+        .resType = CU_RESOURCE_TYPE_PITCH2D,
+        .res.pitch2D.format = pixel_size == 1 ?
+                              CU_AD_FORMAT_UNSIGNED_INT8 :
+                              CU_AD_FORMAT_UNSIGNED_INT16,
+        .res.pitch2D.numChannels = channels,
+        .res.pitch2D.width = src_width,
+        .res.pitch2D.height = src_height,
+        .res.pitch2D.pitchInBytes = src_pitch,
+        .res.pitch2D.devPtr = (CUdeviceptr)src_dptr,
+    };
+
+    ret = CHECK_CU(cu->cuTexObjectCreate(&tex, &res_desc, &tex_desc, NULL));
+    if (ret < 0)
+        goto exit;
+
+    ret = CHECK_CU(cu->cuLaunchKernel(func,
+                                      DIV_UP(dst_width, BLOCKX), DIV_UP(dst_height, BLOCKY), 1,
+                                      BLOCKX, BLOCKY, 1, 0, s->cu_stream, args_uchar, NULL));
+
+exit:
+    if (tex)
+        CHECK_CU(cu->cuTexObjectDestroy(tex));
+
+    return ret;
+}
+
+static int run_cudaresize(AVFilterContext *ctx, AVFrame *in)
+{
+    CUDASignContext *s = ctx->priv;
+    CudaFunctions *cu = s->hwctx->internal->cuda_dl;
+    int ret;
+
+    CUDA_MEMCPY2D cpy = { 0 };
+
+    call_boxsum_kernel(ctx, s->cu_func_boxsum, 1,
+                in->data[0], in->width, in->height, in->linesize[0],
+                (uint8_t*)s->boxgpubuff, W_SIGN, H_SIGN, W_SIGN,
+                1, 8);
+    
+    cpy.srcMemoryType = CU_MEMORYTYPE_DEVICE;
+    cpy.dstMemoryType = CU_MEMORYTYPE_HOST;
+    cpy.srcDevice = s->boxgpubuff;
+    cpy.dstHost = s->boxcpubuff;
+    cpy.srcPitch = W_SIGN * sizeof(int64_t);
+    cpy.dstPitch = W_SIGN * sizeof(int64_t);
+    cpy.WidthInBytes = W_SIGN * sizeof(int64_t);
+    cpy.Height = H_SIGN;
+
+    ret = CHECK_CU(cu->cuMemcpy2DAsync(&cpy, s->cu_stream));
+
+    return ret;
+}
+
+static int cudasign_filter_frame(AVFilterLink *link, AVFrame *in)
+{
+    AVFilterContext         *ctx = link->dst;
+    CUDASignContext         *s = ctx->priv;
+    AVFilterLink            *outlink = ctx->outputs[0];
+    CudaFunctions           *cu = s->hwctx->internal->cuda_dl;
+    StreamContext           *sc = s->streamcontexts;
+    FineSignature* fs;
+
+    uint64_t intpic[32][32];
+    uint64_t rowcount;
+    int i, j, ret;
+    int32_t dh1 = 1, dh2 = 1, dw1 = 1, dw2 = 1, a, b;
+    int64_t denom;
+    int64_t *pp;
+    int64_t precfactor;
+    
+    CUcontext dummy;
+
+    ret = CHECK_CU(cu->cuCtxPushCurrent(s->hwctx->cuda_ctx));
+    if (ret < 0)
+        goto fail;
+    //run box filter
+    ret = run_cudaresize(ctx, in);
+
+    CHECK_CU(cu->cuCtxPopCurrent(&dummy));
+    if (ret < 0)
+        goto fail;
+    
+    precfactor = (sc->divide) ? 65536 : BLOCK_LCM;
+    
+    /* initialize fs */
+    if (sc->curfinesig) {
+        fs = av_mallocz(sizeof(FineSignature));
+        if (!fs)
+            return AVERROR(ENOMEM);
+        sc->curfinesig->next = fs;
+        fs->prev = sc->curfinesig;
+        sc->curfinesig = fs;
+    } else {
+        fs = sc->curfinesig = sc->finesiglist;
+        sc->curcoarsesig1->first = fs;
+    }
+    fs->pts = in->pts;
+    fs->index = sc->lastindex++;
+    
+    //copy box scaled buffer
+    pp = s->boxcpubuff;
+    
+    for (i =0; i< H_SIGN; i++) {
+        memcpy(intpic[i], pp, W_SIGN * sizeof(int64_t));
+        pp += W_SIGN;
+    }
+    /* The following calculates a summed area table (intpic) and brings the numbers
+     * in intpic to the same denominator.
+     * So you only have to handle the numinator in the following sections.
+     */
+    dh1 = link->h / 32;
+    if (link->h % 32)
+        dh2 = dh1 + 1;
+    dw1 = link->w / 32;
+    if (link->w % 32)
+        dw2 = dw1 + 1;
+    denom = (sc->divide) ? dh1 * dh2 * dw1 * dw2 : 1;
+
+    for (i = 0; i < 32; i++) {
+        rowcount = 0;
+        a = 1;
+        if (dh2 > 1) {
+            a = ((link->h*(i+1))%32 == 0) ? (link->h*(i+1))/32 - 1 : (link->h*(i+1))/32;
+            a -= ((link->h*i)%32 == 0) ? (link->h*i)/32 - 1 : (link->h*i)/32;
+            a = (a == dh1)? dh2 : dh1;
+        }
+        for (j = 0; j < 32; j++) {
+            b = 1;
+            if (dw2 > 1) {
+                b = ((link->w*(j+1))%32 == 0) ? (link->w*(j+1))/32 - 1 : (link->w*(j+1))/32;
+                b -= ((link->w*j)%32 == 0) ? (link->w*j)/32 - 1 : (link->w*j)/32;
+                b = (b == dw1)? dw2 : dw1;
+            }
+            rowcount += intpic[i][j] * a * b * precfactor / denom;
+            if (i > 0) {
+                intpic[i][j] = intpic[i-1][j] + rowcount;
+            } else {
+                intpic[i][j] = rowcount;
+            }
+        }
+    }
+
+    denom = (sc->divide) ? 1 : dh1 * dh2 * dw1 * dw2;
+    ret = calc_signature(ctx, sc, fs, intpic, denom, precfactor);
+    if (ret < 0)
+        goto fail;
+
+    //passthrough
+    return ff_filter_frame(outlink, in);
+fail:
+    av_frame_free(&in);    
+    return ret;
+}
+
+static int export(AVFilterContext *ctx, StreamContext *sc, int input)
+{
+    CUDASignContext* sic = ctx->priv;
+    char filename[1024];
+
+    if (av_strlcpy(filename, sic->filename, sizeof(filename)) >= sizeof(filename))
+        return AVERROR(EINVAL);
+
+    if (sic->format == FORMAT_XML) {
+        return xml_export(ctx, sc, filename);
+    } else {
+        return binary_export(ctx, sc, filename);
+    }
+}
+
+static av_cold int cudasign_init(AVFilterContext *ctx)
+{
+    CUDASignContext *s = ctx->priv;
+    StreamContext *sc;
+
+    s->boxcpubuff = (int64_t*)av_malloc_array(PIXELS_SIGN, sizeof(int64_t));
+    if (!s->boxcpubuff)
+        return AVERROR(ENOMEM);
+
+    s->streamcontexts = av_mallocz(sizeof(StreamContext));
+    if (!s->streamcontexts)
+        return AVERROR(ENOMEM);
+    sc = s->streamcontexts;
+
+    sc->lastindex = 0;
+    sc->finesiglist = av_mallocz(sizeof(FineSignature));
+    if (!sc->finesiglist)
+        return AVERROR(ENOMEM);
+    sc->curfinesig = NULL;
+
+    sc->coarsesiglist = av_mallocz(sizeof(CoarseSignature));
+    if (!sc->coarsesiglist)
+        return AVERROR(ENOMEM);
+    sc->curcoarsesig1 = sc->coarsesiglist;
+    sc->coarseend = sc->coarsesiglist;
+    sc->coarsecount = 0;
+    sc->midcoarse = 0; 
+
+    return 0;
+}
+
+static av_cold void cudasign_uninit(AVFilterContext *ctx)
+{
+    CUDASignContext *s = ctx->priv;
+    StreamContext *sc;
+    FineSignature* finsig;
+    CoarseSignature* cousig;
+    void* tmp;
+
+    if (s->hwctx && s->cu_module) {
+        CudaFunctions *cu = s->hwctx->internal->cuda_dl;
+        CUcontext dummy;
+
+        CHECK_CU(cu->cuCtxPushCurrent(s->hwctx->cuda_ctx));
+        if (s->boxgpubuff) {
+            CHECK_CU(cu->cuMemFree(s->boxgpubuff));
+            s->boxgpubuff = 0;
+        }
+        CHECK_CU(cu->cuModuleUnload(s->cu_module));
+        s->cu_module = NULL;
+        CHECK_CU(cu->cuCtxPopCurrent(&dummy));
+    }
+    //free hw_frames_ctx buffer for passthrough
+    av_buffer_unref(&s->frames_ctx);
+
+    if(s->boxcpubuff)
+        av_freep(&s->boxcpubuff);
+
+    if(s->streamcontexts) {
+        sc = s->streamcontexts;
+
+        if (sc->lastindex > 0 && strlen(s->filename) > 0) {
+            export(ctx, sc, 0);
+            sc->exported = 1;
+        }
+
+        finsig = sc->finesiglist;
+        cousig = sc->coarsesiglist;
+
+        while (finsig) {
+            tmp = finsig;
+            finsig = finsig->next;
+            av_freep(&tmp);
+        }
+        sc->finesiglist = NULL;
+
+        while (cousig) {
+            tmp = cousig;
+            cousig = cousig->next;
+            av_freep(&tmp);
+        }
+        sc->coarsesiglist = NULL;        
+        av_freep(&s->streamcontexts);
+    }    
+}
+
+static const AVClass cudasign_class = {
+    .class_name = "cudasign",
+    .item_name  = av_default_item_name,
+    .option     = options,
+    .version    = LIBAVUTIL_VERSION_INT,
+};
+
+static const AVFilterPad cudasign_inputs[] = {
+    {
+        .name        = "default",
+        .type        = AVMEDIA_TYPE_VIDEO,
+        .filter_frame = cudasign_filter_frame,
+        .get_buffer.video = get_pass_video_buffer,
+    },
+    { NULL }
+};
+
+static const AVFilterPad cudasign_outputs[] = {
+    {
+        .name         = "default",
+        .type         = AVMEDIA_TYPE_VIDEO,
+        .config_props = cudasign_config_props,
+    },
+    { NULL }
+};
+
+AVFilter ff_vf_signature_cuda = {
+    .name      = "signature_cuda",
+    .description = NULL_IF_CONFIG_SMALL("GPU accelerated video resizer"),
+
+    .init          = cudasign_init,
+    .uninit        = cudasign_uninit,
+    FILTER_QUERY_FUNC(cudasign_query_formats),
+
+    .priv_size = sizeof(CUDASignContext),
+    .priv_class = &cudasign_class,
+
+    .inputs    = cudasign_inputs,
+    .outputs   = cudasign_outputs,
+
+    .flags_internal = FF_FILTER_FLAG_HWFRAME_AWARE,
+};

--- a/libavfilter/vf_signature_cuda.cu
+++ b/libavfilter/vf_signature_cuda.cu
@@ -1,0 +1,38 @@
+#include "cuda/vector_helpers.cuh"
+
+typedef unsigned long long int uint64_cu;
+
+extern "C" {
+
+__global__ void  Subsample_Boxsumint64(cudaTextureObject_t tex,
+                                         uint64_cu *dst,
+                                         int dst_width, int dst_height, int dst_pitch,
+                                         int src_width, int src_height,
+                                         int bit_depth)
+{
+
+    int xo = blockIdx.x * blockDim.x + threadIdx.x;
+    int yo = blockIdx.y * blockDim.y + threadIdx.y;
+
+    if (yo < dst_height && xo < dst_width)
+    {
+        float hscale = (float)src_width / (float)dst_width;
+        float vscale = (float)src_height / (float)dst_height;
+        
+        int xs = (int)(hscale * xo);
+        int xe = (int)(xs + hscale); xe = min(src_width-1,xe);
+        int ys = (int)(vscale * yo);
+        int ye = (int)(ys + vscale); ye = min(src_height-1,ye);
+
+        int index = yo*dst_pitch+xo;
+        uint64_cu sum = 0;
+        for(int i = xs; i <= xe; i++) {
+            for(int j = ys; j <= ye; j++) {
+                sum += (uint64_cu)(tex2D<uchar>(tex, i, j));
+            }
+        }
+        dst[index] = sum;
+    }
+}
+
+}

--- a/libavutil/Makefile
+++ b/libavutil/Makefile
@@ -81,6 +81,7 @@ HEADERS = adler32.h                                                     \
           sha512.h                                                      \
           spherical.h                                                   \
           stereo3d.h                                                    \
+          thread.h                                                      \
           threadmessage.h                                               \
           time.h                                                        \
           timecode.h                                                    \


### PR DESCRIPTION
This is taking the bits we want to keep from the previous Ffmpeg fork (https://github.com/livepeer/FFmpeg/compare/dc91b913b6260e85e1304c74ff7bb3c22a8c9fb1...2e18d069668c143f3c251067abd25389e411d022) and applying them on top of a new fork from the most recent commit